### PR TITLE
[RSDK-9278] add default pwm frequency option for pinctrl boards

### DIFF
--- a/pi5/board.go
+++ b/pi5/board.go
@@ -136,7 +136,7 @@ func (b *pinctrlpi5) reconfigurePullUpPullDowns(newConf *Config) error {
 	for _, pullConf := range newConf.Pulls {
 		pin, ok := b.gpioMappings[pullConf.Pin]
 		if !ok {
-			return errors.New("unexpected pull")
+			return fmt.Errorf("pin %v could not be found", pullConf.Pin)
 		}
 		gpioNum := pin.GPIO
 		switch pullConf.Pull {

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -24,6 +24,8 @@ import (
 // Model for rpi5.
 var Model = resource.NewModel("viam-labs", "pinctrl", "rpi5")
 
+const defaultPWMFreqHz = 800 // default used in pigpio
+
 func init() {
 	gpioMappings, err := gl.GetGPIOBoardMappings(Model.Name, boardInfoMappings)
 	var noBoardErr gl.NoBoardFoundError
@@ -134,7 +136,7 @@ func newBoard(
 
 	// Initialize the GPIO pins
 	for newName, mapping := range gpioMappings {
-		b.gpios[newName] = b.boardPinCtrl.CreateGpioPin(mapping)
+		b.gpios[newName] = b.boardPinCtrl.CreateGpioPin(mapping, 800)
 	}
 
 	if err := b.Reconfigure(ctx, nil, conf); err != nil {

--- a/pi5/board.go
+++ b/pi5/board.go
@@ -36,39 +36,6 @@ func init() {
 	RegisterBoard(Model.Name, gpioMappings)
 }
 
-// pins are stored in /dev/gpiomem in order of gpio nums, so we must convert from pin name (physical num) to GPIO number.
-// these are redundant with gpioMappings from gl.GetGPIOBoardMappings/data.go
-var pinNameToGPIONum = map[string]int{
-	"3":  2,
-	"5":  3,
-	"7":  4,
-	"8":  14,
-	"10": 15,
-	"11": 17,
-	"12": 18,
-	"13": 27,
-	"15": 22,
-	"16": 23,
-	"18": 24,
-	"19": 10,
-	"21": 9,
-	"22": 25,
-	"23": 11,
-	"24": 8,
-	"26": 7,
-	"27": 0,
-	"28": 1,
-	"29": 5,
-	"31": 6,
-	"32": 12,
-	"33": 13,
-	"35": 19,
-	"36": 16,
-	"37": 26,
-	"38": 20,
-	"40": 21,
-}
-
 // register values for configuring pull up/pull down in mem.
 const (
 	pullNoneMode = 0x0
@@ -136,7 +103,7 @@ func newBoard(
 
 	// Initialize the GPIO pins
 	for newName, mapping := range gpioMappings {
-		b.gpios[newName] = b.boardPinCtrl.CreateGpioPin(mapping, 800)
+		b.gpios[newName] = b.boardPinCtrl.CreateGpioPin(mapping, defaultPWMFreqHz)
 	}
 
 	if err := b.Reconfigure(ctx, nil, conf); err != nil {
@@ -167,7 +134,11 @@ func (b *pinctrlpi5) Reconfigure(
 
 func (b *pinctrlpi5) reconfigurePullUpPullDowns(newConf *Config) error {
 	for _, pullConf := range newConf.Pulls {
-		gpioNum := pinNameToGPIONum[pullConf.Pin]
+		pin, ok := b.gpioMappings[pullConf.Pin]
+		if !ok {
+			return errors.New("unexpected pull")
+		}
+		gpioNum := pin.GPIO
 		switch pullConf.Pull {
 		case "none":
 			b.pulls[gpioNum] = pullNoneMode

--- a/pinctrl/gpio.go
+++ b/pinctrl/gpio.go
@@ -38,11 +38,14 @@ type GPIOPin struct {
 }
 
 // CreateGpioPin creates a gpio pin.
-func (ctrl *Pinctrl) CreateGpioPin(mapping gl.GPIOBoardMapping) *GPIOPin {
+// defaultPWMFreqHz is used to initialize the pwmFreqHz of the pin.
+// This prevents SetPWM calls from failing silently for the user, if the default frequency is set to a nonzero value
+func (ctrl *Pinctrl) CreateGpioPin(mapping gl.GPIOBoardMapping, defaultPWMFreqHz uint) *GPIOPin {
 	pin := GPIOPin{
 		devicePath: mapping.GPIOChipDev,
 		offset:     uint32(mapping.GPIO),
 		logger:     ctrl.logger,
+		pwmFreqHz:  defaultPWMFreqHz,
 	}
 	if mapping.HWPWMSupported {
 		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, ctrl.logger, &ctrl.VPage)

--- a/pinctrl/gpio.go
+++ b/pinctrl/gpio.go
@@ -39,7 +39,7 @@ type GPIOPin struct {
 
 // CreateGpioPin creates a gpio pin.
 // defaultPWMFreqHz is used to initialize the pwmFreqHz of the pin.
-// This prevents SetPWM calls from failing silently for the user, if the default frequency is set to a nonzero value.
+// Allows users to define a pwm using just SetPWM calls when testing, if the default frequency is set to a nonzero value.
 func (ctrl *Pinctrl) CreateGpioPin(mapping gl.GPIOBoardMapping, defaultPWMFreqHz uint) *GPIOPin {
 	pin := GPIOPin{
 		devicePath: mapping.GPIOChipDev,

--- a/pinctrl/gpio.go
+++ b/pinctrl/gpio.go
@@ -39,7 +39,7 @@ type GPIOPin struct {
 
 // CreateGpioPin creates a gpio pin.
 // defaultPWMFreqHz is used to initialize the pwmFreqHz of the pin.
-// This prevents SetPWM calls from failing silently for the user, if the default frequency is set to a nonzero value
+// This prevents SetPWM calls from failing silently for the user, if the default frequency is set to a nonzero value.
 func (ctrl *Pinctrl) CreateGpioPin(mapping gl.GPIOBoardMapping, defaultPWMFreqHz uint) *GPIOPin {
 	pin := GPIOPin{
 		devicePath: mapping.GPIOChipDev,
@@ -48,7 +48,7 @@ func (ctrl *Pinctrl) CreateGpioPin(mapping gl.GPIOBoardMapping, defaultPWMFreqHz
 		pwmFreqHz:  defaultPWMFreqHz,
 	}
 	if mapping.HWPWMSupported {
-		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, ctrl.logger, &ctrl.VPage)
+		pin.hwPwm = newPwmDevice(mapping.PWMSysFsDir, mapping.PWMID, mapping.GPIO, ctrl.logger, &ctrl.VPage)
 	}
 	return &pin
 }

--- a/pinctrl/hw_pwm.go
+++ b/pinctrl/hw_pwm.go
@@ -76,7 +76,8 @@ const (
 
 type pwmDevice struct {
 	chipPath string
-	line     int
+	pwmLine  int
+	gpioLine int
 
 	// We have no mutable state, but the mutex is used to write to multiple pseudofiles atomically.
 	mu     sync.Mutex
@@ -87,8 +88,8 @@ type pwmDevice struct {
 	gpioPinsPage *mmap.MMap
 }
 
-func newPwmDevice(chipPath string, line int, logger logging.Logger, gpioPinsPage *mmap.MMap) *pwmDevice {
-	return &pwmDevice{chipPath: chipPath, line: line, logger: logger, gpioPinsPage: gpioPinsPage}
+func newPwmDevice(chipPath string, pwmLine, gpioLine int, logger logging.Logger, gpioPinsPage *mmap.MMap) *pwmDevice {
+	return &pwmDevice{chipPath: chipPath, pwmLine: pwmLine, gpioLine: gpioLine, logger: logger, gpioPinsPage: gpioPinsPage}
 }
 
 func writeValue(filepath string, value uint64, logger logging.Logger) error {
@@ -102,8 +103,9 @@ func writeValue(filepath string, value uint64, logger logging.Logger) error {
 	// we're trying to debug something in here, log the error even if it will later be ignored.
 	if err != nil {
 		logger.Debugf("Encountered error writing to sysfs: %s", err)
+		return errors.Join(err, errors.New(filepath))
 	}
-	return errors.Join(err, errors.New(filepath))
+	return nil
 }
 
 func (pwm *pwmDevice) writeChip(filename string, value uint64) error {
@@ -111,7 +113,7 @@ func (pwm *pwmDevice) writeChip(filename string, value uint64) error {
 }
 
 func (pwm *pwmDevice) linePath() string {
-	return fmt.Sprintf("%s/pwm%d", pwm.chipPath, pwm.line)
+	return fmt.Sprintf("%s/pwm%d", pwm.chipPath, pwm.pwmLine)
 }
 
 func (pwm *pwmDevice) writeLine(filename string, value uint64) error {
@@ -123,13 +125,13 @@ func (pwm *pwmDevice) export() error {
 	if _, err := os.Lstat(pwm.linePath()); err != nil {
 		if os.IsNotExist(err) {
 			// happy path
-			return pwm.writeChip("export", uint64(pwm.line))
+			return pwm.writeChip("export", uint64(pwm.pwmLine))
 		}
 		return err // Something unexpected has gone wrong.
 	}
 	// Otherwise, the line we're trying to export already exists.
 	pwm.logger.Debugf("Skipping re-export of already-exported line %d on HW PWM chip %s",
-		pwm.line, pwm.chipPath)
+		pwm.pwmLine, pwm.chipPath)
 	return nil
 }
 
@@ -139,7 +141,7 @@ func (pwm *pwmDevice) unexport() error {
 	if _, err := os.Lstat(pwm.linePath()); err != nil {
 		if os.IsNotExist(err) {
 			pwm.logger.Debugf("Skipping unexport of already-unexported line %d on HW PWM chip %s",
-				pwm.line, pwm.chipPath)
+				pwm.pwmLine, pwm.chipPath)
 			return nil
 		}
 		return err // Something has gone wrong.
@@ -156,7 +158,7 @@ func (pwm *pwmDevice) unexport() error {
 	// the pin too quickly after changing something else about it (e.g., disabling it), the whole
 	// PWM system gets corrupted. Sleep for a small amount of time to avoid this.
 	time.Sleep(10 * time.Millisecond)
-	if err := pwm.writeChip("unexport", uint64(pwm.line)); err != nil {
+	if err := pwm.writeChip("unexport", uint64(pwm.pwmLine)); err != nil {
 		return err
 	}
 
@@ -184,13 +186,34 @@ func (pwm *pwmDevice) disable() error {
 // Only call this from public functions, to avoid double-wrapping the errors.
 func (pwm *pwmDevice) wrapError(err error) error {
 	if err != nil {
-		return errors.Join(err, fmt.Errorf("HW PWM chipPath %s, line %d", pwm.chipPath, pwm.line))
+		return errors.Join(err, fmt.Errorf("HW PWM chipPath %s, line %d", pwm.chipPath, pwm.pwmLine))
 	}
 	return nil
 }
 
+/*
+For all pins belonging to the same bank, pin data is stored contiguously and in 8 byte chunks.
+For a given pin, this method determines:
+
+ 1. which bank the pin belongs to
+
+ 2. the starting address of its 8 byte data chunk.
+
+    note: numGPIOPins is a hardcoded value for the pi5
+*/
+func getGPIOPinAddress(gpioNumber int) (int64, error) {
+	const pinDataSizeBytes = 0x8 // 4 bytes = control status bits, 4 bytes to represent all possible control modes. 8 bytes per pin
+
+	if !(1 <= gpioNumber && gpioNumber <= numGPIOPins) {
+		return -1, errors.New("pin is out of bank range")
+	}
+
+	pinAddressOffset := (gpioNumber * pinDataSizeBytes)
+	return int64(pinAddressOffset), nil
+}
+
 // updates the given mode of a pin by finding its specific location in memory & writing to the 'mode' byte in the 8 byte block of pin data.
-func (pwm *pwmDevice) writeToPinModeByte(gpioNumber int, newMode byte) error {
+func (pwm *pwmDevice) SetPinMode(pinMode byte) (err error) {
 	/*
 		Remember that GPIO mode data is stored in a different area of memory, and this area of memory relates to
 		setting alternative modes; in this case we set ALT3 (PWM Mode). When we want to use GPIO Mode, we will set the
@@ -205,7 +228,7 @@ func (pwm *pwmDevice) writeToPinModeByte(gpioNumber int, newMode byte) error {
 	*/
 
 	// Find base address of GPIO Pin in memory:
-	pinAddress, err := getGPIOPinAddress(gpioNumber)
+	pinAddress, err := getGPIOPinAddress(pwm.gpioLine)
 	if err != nil {
 		return fmt.Errorf("error getting gpio pin address: %w", err)
 	}
@@ -213,58 +236,9 @@ func (pwm *pwmDevice) writeToPinModeByte(gpioNumber int, newMode byte) error {
 	// Get pin's memory contents from virtual page; set the 5th byte of pin to mode
 	altModeIndex := int64(4)
 	vPage := *(pwm.gpioPinsPage)
-	vPage[pinAddress+altModeIndex] = newMode
+	vPage[pinAddress+altModeIndex] = pinMode
 
 	return nil
-}
-
-/*
-For all pins belonging to the same bank, pin data is stored contiguously and in 8 byte chunks.
-For a given pin, this method determines:
- 1. which bank the pin belongs to
- 2. the starting address of its 8 byte data chunk.
-*/
-func getGPIOPinAddress(gpioNumber int) (int64, error) {
-	const pinDataSizeBytes = 0x8 // 4 bytes = control status bits, 4 bytes to represent all possible control modes. 8 bytes per pin
-
-	if !(1 <= gpioNumber && gpioNumber <= numGPIOPins) {
-		return -1, errors.New("pin is out of bank range")
-	}
-
-	pinAddressOffset := (gpioNumber * pinDataSizeBytes)
-	return int64(pinAddressOffset), nil
-}
-
-/*
-This function uses pwm.line to determine what GPIO Pin it needs to set to the inputted mode
-Each pwm line corresponds to a GPIO Pin. The pi5 mapping is:
-
-	PWM Line 0 -> GPIO 12
-	PWM Line 1 -> GPIO 13
-	PWM Line 2 -> GPIO 18
-	PWM Line 3 -> GPIO 19
-
-Other mappings for different pis can be found here:  https://pypi.org/project/rpi-hardware-pwm/#modal-close
-
-Use the writeToPinModeByte to set the mode to PWM or GPIO using this helper method. Pin Mode will either be 'PWMMode' or 'GPIO'
-
-TODO: Make writing to GPIO Pins generalizeable, and not dependent on the pwm following this exact structure.
-*/
-func (pwm *pwmDevice) SetPinMode(pinMode byte) (err error) {
-	switch pwm.line {
-	case 0:
-		err = pwm.writeToPinModeByte(12, pinMode)
-	case 1:
-		err = pwm.writeToPinModeByte(13, pinMode)
-	case 2:
-		err = pwm.writeToPinModeByte(18, pinMode)
-	case 3:
-		err = pwm.writeToPinModeByte(19, pinMode)
-	default:
-		return errors.New("attempting to use unknown PWM line")
-	}
-
-	return err
 }
 
 // SetPwm configures an exported pin and enables its output signal.
@@ -279,12 +253,10 @@ func (pwm *pwmDevice) SetPwm(freqHz uint, dutyCycle float64) (err error) {
 	defer func() {
 		err = pwm.wrapError(err)
 	}()
-
 	// Set pin mode to hardware pwm enabled before using PWM.
 	if err := pwm.SetPinMode(PWMMode); err != nil {
 		return err
 	}
-
 	// Every time this pin is used as a (non-PWM) GPIO input or output, it gets unexported on the
 	// PWM chip. Make sure to re-export it here.
 	if err := pwm.export(); err != nil {
@@ -302,7 +274,7 @@ func (pwm *pwmDevice) SetPwm(freqHz uint, dutyCycle float64) (err error) {
 		// to 0, and enabling the pin with a period of 0 results in errors. Let's try making the
 		// period non-zero and enabling it again.
 		pwm.logger.Debugf("Cannot enable HW PWM device %s line %d, will try changing period: %s",
-			pwm.chipPath, pwm.line, err)
+			pwm.chipPath, pwm.pwmLine, err)
 		if err := pwm.writeLine("period", safePeriodNs); err != nil {
 			return err
 		}

--- a/pinctrl/hw_pwm.go
+++ b/pinctrl/hw_pwm.go
@@ -215,6 +215,11 @@ func getGPIOPinAddress(gpioNumber int) (int64, error) {
 	return int64(pinAddressOffset), nil
 }
 
+/*
+TODO: Make sure this code works for other boards
+Other mappings for different pis can be found here:  https://pypi.org/project/rpi-hardware-pwm/#modal-close
+
+*/
 // updates the given mode of a pin by finding its specific location in memory & writing to the 'mode' byte in the 8 byte block of pin data.
 func (pwm *pwmDevice) SetPinMode(pinMode byte) error {
 	/*

--- a/pinctrl/hw_pwm.go
+++ b/pinctrl/hw_pwm.go
@@ -194,16 +194,17 @@ func (pwm *pwmDevice) wrapError(err error) error {
 /*
 For all pins belonging to the same bank, pin data is stored contiguously and in 8 byte chunks.
 For a given pin, this method determines:
-
  1. which bank the pin belongs to
-
+    Currently this code is specific to the pi5, so we know that all of our pins have to be within bank 0.
+    Eventually we should change this to handle other banks
  2. the starting address of its 8 byte data chunk.
 
-    note: numGPIOPins is a hardcoded value for the pi5
+note: numGPIOPins is a hardcoded value for the pi5
 */
 func getGPIOPinAddress(gpioNumber int) (int64, error) {
-	const pinDataSizeBytes = 0x8 // 4 bytes = control status bits, 4 bytes to represent all possible control modes. 8 bytes per pin
+	const pinDataSizeBytes = 0x8 // 8 bytes per pin: 4 bytes represent control statuses and 4 bytes are for different control modes
 
+	// check that the given pin is in bank 0(it should be)
 	if !(1 <= gpioNumber && gpioNumber <= numGPIOPins) {
 		return -1, errors.New("pin is out of bank range")
 	}


### PR DESCRIPTION
https://viam.atlassian.net/browse/RSDK-9278

this adds a way for implementers to define a default pwm frequency for their pinctrl board, so users do not get confused when setting a PWM does not work.

Additionally removes some redundant pinmapping definitions in the code. 

Worth noting that the hw_pwm.go code still appears to be specific to the pi5, and may or may not actually use pinctrl. `hw_pwm.go` writes to sysfs for modifying the pwm, and updates `vPage` for the pin with which pinmode is being used.

software pwm uses the `gpio.Line` from `github.com/mkch/gpio` to set the gpio pin high & low manually, by opening the chip path defined in `data.go` for the pin.

tested on a pi5 with both hardware and software pwm, both using the default frequency and changing the frequency on a pin worked